### PR TITLE
Add API to receive acks when writing data to a characteristic.

### DIFF
--- a/Adafruit_BluefruitLE/corebluetooth/device.py
+++ b/Adafruit_BluefruitLE/corebluetooth/device.py
@@ -42,6 +42,7 @@ class CoreBluetoothDevice(Device):
         self._advertised = []
         self._discovered_services = set()
         self._char_on_changed = {}
+        self._char_on_write_ack = {}
         self._rssi = None
         # Events to signify when an asyncronous request has finished.
         self._connected = threading.Event()
@@ -115,6 +116,12 @@ class CoreBluetoothDevice(Device):
         # characteristic.
         self._char_on_changed[characteristic] = on_change
 
+    def _write_ack_characteristic(self, characteristic, on_ack):
+        """Call the specified on_ack callback when this characteristic receives
+        a write acknowledgement.
+        """
+        self._char_on_write_ack[characteristic] = on_ack
+
     def _characteristic_changed(self, characteristic):
         """Called when the specified characteristic has changed its value."""
         # Called when a characteristic is changed.  Get the on_changed handler
@@ -127,6 +134,11 @@ class CoreBluetoothDevice(Device):
         char = characteristic_list().get(characteristic)
         if char is not None:
             char._value_read.set()
+
+    def _characteristic_write_ack(self, characteristic):
+        on_write_ack = self._char_on_write_ack.get(characteristic, None)
+        if on_write_ack is not None:
+            on_write_ack()
 
     def _descriptor_changed(self, descriptor):
         """Called when the specified descriptor has changed its value."""

--- a/Adafruit_BluefruitLE/corebluetooth/gatt.py
+++ b/Adafruit_BluefruitLE/corebluetooth/gatt.py
@@ -115,6 +115,18 @@ class CoreBluetoothGattCharacteristic(GattCharacteristic):
         self._device._peripheral.setNotifyValue_forCharacteristic_(False,
             self._characteristic)
 
+    def start_write_ack(self, on_ack):
+        """Enable notification of write acknowledgments for this characteristic
+        using the specified on_ack callback.  on_ack should be a function
+        with no parameters.
+        """
+        # Tell the device what callback to use for changes to this characteristic.
+        self._device._write_ack_characteristic(self._characteristic, on_ack)
+
+    def stop_write_ack(self):
+        """Disable notification of write acknowledgments for this characteristic."""
+        self._device._write_ack_characteristic(self._characteristic, None)
+
     def list_descriptors(self):
         """Return list of GATT descriptors that have been discovered for this
         characteristic.

--- a/Adafruit_BluefruitLE/corebluetooth/provider.py
+++ b/Adafruit_BluefruitLE/corebluetooth/provider.py
@@ -169,6 +169,13 @@ class CentralDelegate(object):
     def peripheral_didWriteValueForCharacteristic_error_(self, peripheral, characteristic, error):
         # Characteristic write succeeded.  Ignored for now.
         logger.debug('peripheral_didWriteValueForCharacteristic_error called')
+        # Stop if there was some kind of error.
+        if error is not None:
+            return
+        # Notify the device that the value was received.
+        device = device_list().get(peripheral)
+        if device is not None:
+            device._characteristic_write_ack(characteristic)
 
     def peripheral_didUpdateNotificationStateForCharacteristic_error_(self, peripheral, characteristic, error):
         # Characteristic notification state updated.  Ignored for now.

--- a/Adafruit_BluefruitLE/interfaces/gatt.py
+++ b/Adafruit_BluefruitLE/interfaces/gatt.py
@@ -85,6 +85,19 @@ class GattCharacteristic(object):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def start_write_ack(self, on_ack):
+        """Enable notification of write acknowledgments for this characteristic
+        using the specified on_ack callback.  on_ack should be a function
+        with no parameters.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def stop_write_ack(self):
+        """Disable notification of write acknowledgments for this characteristic."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def list_descriptors(self):
         """Return list of GATT descriptors that have been discovered for this
         characteristic.


### PR DESCRIPTION
I've implemented this for Core Bluetooth / OS X.  I don't have a Linux machine handy to do the bluez implementation.  I tried to follow the existing naming conventions as closely as possible, let me know if it needs tweaks.
