### PR TITLE
Changing counters to sets since counters will return True in undesirable cases (e.g., two unequal UUIDS).

### DIFF
--- a/Adafruit_BluefruitLE/interfaces/provider.py
+++ b/Adafruit_BluefruitLE/interfaces/provider.py
@@ -28,7 +28,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import abc
-from collections import Counter
 import time
 
 from ..config import TIMEOUT_SEC
@@ -104,8 +103,8 @@ class Provider(object):
         also optional.  Will not block, instead it returns immediately with a
         list of found devices (which might be empty).
         """
-        # Convert service UUID list to counter for quicker comparison.
-        expected = Counter(service_uuids)
+        # Convert service UUID list to set for quicker comparison.
+        expected = set(service_uuids)
         # Grab all the devices.
         devices = self.list_devices()
         # Filter to just the devices that have the requested service UUID/name.
@@ -117,7 +116,7 @@ class Provider(object):
                     found.append(device)
             else:
                 # Check if the advertised UUIDs have at least the expected UUIDs.
-                actual = Counter(device.advertised)
+                actual = set(device.advertised)
                 if actual >= expected:
                     found.append(device)
         return found


### PR DESCRIPTION

>>> Counter([UUID('bd4ac610-0b45-11e3-8ffd-0800200c9a66')]) >= Counter([UUID('6e400001-b5a3-f393-e0a9-e50e24dcca9e')])
True
>>> set([UUID('bd4ac610-0b45-11e3-8ffd-0800200c9a66')]) >= set([UUID('6e400001-b5a3-f393-e0a9-e50e24dcca9e')])
False