### PR TITLE
corebluetooth: Properly raise exceptions

### DIFF
--- a/Adafruit_BluefruitLE/corebluetooth/provider.py
+++ b/Adafruit_BluefruitLE/corebluetooth/provider.py
@@ -289,7 +289,7 @@ class CoreBluetoothProvider(Provider):
         """
         # Rethrow exception with its original stack trace following advice from:
         # http://nedbatchelder.com/blog/200711/rethrowing_exceptions_in_python.html
-        raise_(exec_info[1], exec_info[2])
+        raise_(exec_info[1], None, exec_info[2])
 
     def list_adapters(self):
         """Return a list of BLE adapter objects connected to the system."""


### PR DESCRIPTION
Currently, `CoreBluetoothProvider._raise_error` improperly passes the exception traceback as `value` to `raise_`, causing `TypeError: instance exception may not have a separate value` to be thrown instead of the real exception.

This patch fixes that error, matching the behaviour of the BlueZ driver (https://github.com/adafruit/Adafruit_Python_BluefruitLE/blob/master/Adafruit_BluefruitLE/bluez_dbus/provider.py#L105).

Testing this patch is easy: add anything that throws an exception (e.g. `1/0`) to the main loop of an example app and run it under macOS.