### PR TITLE
coreBluetooth: Get Service UUIDs from both AD and EIR

### DIFF
--- a/Adafruit_BluefruitLE/corebluetooth/device.py
+++ b/Adafruit_BluefruitLE/corebluetooth/device.py
@@ -96,7 +96,7 @@ class CoreBluetoothDevice(Device):
         # Advertisement data was received, pull out advertised service UUIDs and
         # name from advertisement data.
         if 'kCBAdvDataServiceUUIDs' in advertised:
-            self._advertised = map(cbuuid_to_uuid, advertised['kCBAdvDataServiceUUIDs'])
+            self._advertised = self._advertised + map(cbuuid_to_uuid, advertised['kCBAdvDataServiceUUIDs'])
 
     def _characteristics_discovered(self, service):
         """Called when GATT characteristics have been discovered."""

--- a/Adafruit_BluefruitLE/corebluetooth/provider.py
+++ b/Adafruit_BluefruitLE/corebluetooth/provider.py
@@ -81,7 +81,7 @@ class CentralDelegate(object):
 
     def centralManager_didDiscoverPeripheral_advertisementData_RSSI_(self, manager, peripheral, data, rssi):
         """Called when the BLE adapter found a device while scanning, or has
-        updated advertisement data for a device.
+        new advertisement data for a device.
         """
         logger.debug('centralManager_didDiscoverPeripheral_advertisementData_RSSI called')
         # Log name of device found while scanning.


### PR DESCRIPTION
This fixes service-based device finding for peripherals whose service UUIDs are
split between the Advertisement Data and Scan Response.

`_update_advertised()` was incorrectly ovewriting the service UUIDs included in
Advertisement Data with those in the Scan Response.

Although the documentation is not clear about it, CoreBluetooth's
`didDiscoverPeripheral` will be called two separate times, once with the
Advertisement Data content and a second one with a Scan Response.

See https://lists.apple.com/archives/bluetooth-dev/2012/Apr/msg00047.html