### PR TITLE
pull out the manufacturer data from the advertisement dictionary

### DIFF
--- a/Adafruit_BluefruitLE/corebluetooth/device.py
+++ b/Adafruit_BluefruitLE/corebluetooth/device.py
@@ -100,7 +100,7 @@ class CoreBluetoothDevice(Device):
             self._advertised = self._advertised + map(cbuuid_to_uuid, advertised['kCBAdvDataServiceUUIDs'])
 
         if 'kCBAdvDataManufacturerData' in advertised:
-            self._manufacturerData = advertised['kCBAdvDataManufacturerData'].bytes().tobytes()
+            self._manufacturerData = advertised['kCBAdvDataManufacturerData'].bytes().tolist()
 
     def _characteristics_discovered(self, service):
         """Called when GATT characteristics have been discovered."""

--- a/Adafruit_BluefruitLE/corebluetooth/device.py
+++ b/Adafruit_BluefruitLE/corebluetooth/device.py
@@ -41,6 +41,7 @@ class CoreBluetoothDevice(Device):
         """
         self._peripheral = peripheral
         self._advertised = []
+        self._manufacturerData = None
         self._discovered_services = set()
         self._char_on_changed = {}
         self._rssi = None
@@ -97,6 +98,9 @@ class CoreBluetoothDevice(Device):
         # name from advertisement data.
         if 'kCBAdvDataServiceUUIDs' in advertised:
             self._advertised = self._advertised + map(cbuuid_to_uuid, advertised['kCBAdvDataServiceUUIDs'])
+
+        if 'kCBAdvDataManufacturerData' in advertised:
+            self._manufacturerData = advertised['kCBAdvDataManufacturerData'].bytes().tobytes()
 
     def _characteristics_discovered(self, service):
         """Called when GATT characteristics have been discovered."""
@@ -163,6 +167,11 @@ class CoreBluetoothDevice(Device):
         device.
         """
         return self._advertised
+
+    @property
+    def manufacturerData(self):
+        """Return the manufacturer data from advertisement data, if any."""
+        return self._manufacturerData
 
     @property
     def id(self):


### PR DESCRIPTION
This extends the CoreBluetoothDevice class so that _update_advertised() now also checks if the incoming data includes 'kCBAdvDataManufacturerData' (AKA CBAdvertisementDataManufacturerDataKey) and if so, pulls it out and caches it in a new property "manufacturerData".

