### PR TITLE
change to enable this library to run in background threads and processes

### DIFF
--- a/Adafruit_BluefruitLE/corebluetooth/provider.py
+++ b/Adafruit_BluefruitLE/corebluetooth/provider.py
@@ -237,8 +237,14 @@ class CoreBluetoothProvider(Provider):
         """
         # Setup the central manager and its delegate.
         self._central_manager = CBCentralManager.alloc()
+
+        # Adding the below changes with libdispatch and sending it into the initwith 
+        # delegate means you can now run the library as a background process. 
+        dispatch_queue = libdispatch.dispatch_queue_create(b'q', None)
+
         self._central_manager.initWithDelegate_queue_options_(self._central_delegate,
-                                                              None, None)
+                                                              dispatch_queue, None)
+ 
         # Add any connected devices to list of known devices.
 
 


### PR DESCRIPTION
After trying to run this library as well as a web gui front end I realized that the bluetooth cannot possible run in a thread, process, child sub process and the problem is fixable by adding the following lines to the provider.py initialize function in the CoreBluetoothProvider class.  

        dispatch_queue = libdispatch.dispatch_queue_create(b'q', None)

        self._central_manager.initWithDelegate_queue_options_(self._central_delegate,
                                                              dispatch_queue, None)
 
More details can be seen from this stack overflow post: 
https://stackoverflow.com/questions/48958267/how-can-i-use-corebluetooth-for-python-without-giving-up-the-main-thread?fbclid=IwAR3X9aaK4kAu-BKFJ3yFDM48CMxiJQmw39GhDxnWeXpxKNKnCNUNOzYSZpk

Merging this in will make the library much more robust for a range of application where the bluetooth runs in the background. 

