### PR TITLE
Explicit byte string literal for py3

### DIFF
--- a/examples/uart_service.py
+++ b/examples/uart_service.py
@@ -59,7 +59,7 @@ def main():
         uart = UART(device)
 
         # Write a string to the TX characteristic.
-        uart.write('Hello world!\r\n')
+        uart.write(b'Hello world!\r\n')
         print("Sent 'Hello world!' to the device.")
 
         # Now wait up to one minute to receive data from the device.


### PR DESCRIPTION
This very small change makes the UART example code work in Python 3. 

In Py2, strings are implicitly byte arrays. This isn't the case in Py3. Explicitly marking the data to send as a byte array makes it all happy again.